### PR TITLE
Refactors authentication use cases

### DIFF
--- a/src/main/java/com/todoapp/auth/adapter/in/AuthController.java
+++ b/src/main/java/com/todoapp/auth/adapter/in/AuthController.java
@@ -1,7 +1,8 @@
 package com.todoapp.auth.adapter.in;
 import com.todoapp.auth.dto.LoginRequestDTO;
 import com.todoapp.auth.dto.AuthResponseDTO;
-import com.todoapp.auth.port.in.AuthUseCase;
+import com.todoapp.auth.port.in.LoginUseCase;
+import com.todoapp.auth.port.in.UserContextUseCase;
 import com.todoapp.user.domain.User;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
@@ -13,21 +14,23 @@ import org.springframework.validation.annotation.Validated;
 @Validated
 public class AuthController {
 
-    private final AuthUseCase authUseCase;
+    private final LoginUseCase loginUseCase;
+    private final UserContextUseCase userContextUseCase;
 
-    public AuthController(AuthUseCase authUseCase) {
-        this.authUseCase = authUseCase;
+    public AuthController(LoginUseCase loginUseCase, UserContextUseCase userContextUseCase) {
+        this.loginUseCase = loginUseCase;
+        this.userContextUseCase = userContextUseCase;
     }
 
     @PostMapping("/login")
     public ResponseEntity<AuthResponseDTO> login(@Valid @RequestBody LoginRequestDTO dto) {
-        return ResponseEntity.ok(authUseCase.login(dto));
+        return ResponseEntity.ok(loginUseCase.login(dto));
     }
 
     @GetMapping("/me")
     public ResponseEntity<User> me(@RequestHeader("Authorization") String authHeader) {
         String token = authHeader.replace("Bearer ", "");
-        User user = authUseCase.getCurrentUser(token);
+        User user = userContextUseCase.getCurrentUser(token);
         return ResponseEntity.ok(user);
     }
 }

--- a/src/main/java/com/todoapp/auth/application/AuthService.java
+++ b/src/main/java/com/todoapp/auth/application/AuthService.java
@@ -2,7 +2,8 @@ package com.todoapp.auth.application;
 
 import com.todoapp.auth.dto.LoginRequestDTO;
 import com.todoapp.auth.dto.AuthResponseDTO;
-import com.todoapp.auth.port.in.AuthUseCase;
+import com.todoapp.auth.port.in.LoginUseCase;
+import com.todoapp.auth.port.in.UserContextUseCase;
 import com.todoapp.auth.port.out.JwtEncoder;
 import com.todoapp.auth.port.out.UserCredentialsPort;
 import com.todoapp.user.domain.User;
@@ -14,7 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.NoSuchElementException;
 
 @Service
-public class AuthService implements AuthUseCase {
+public class AuthService implements LoginUseCase, UserContextUseCase {
 
     private final UserCredentialsPort credentials;
     private final JwtEncoder jwtEncoder;

--- a/src/main/java/com/todoapp/auth/port/in/LoginUseCase.java
+++ b/src/main/java/com/todoapp/auth/port/in/LoginUseCase.java
@@ -2,9 +2,7 @@ package com.todoapp.auth.port.in;
 
 import com.todoapp.auth.dto.LoginRequestDTO;
 import com.todoapp.auth.dto.AuthResponseDTO;
-import com.todoapp.user.domain.User;
 
-public interface AuthUseCase {
+public interface LoginUseCase {
     AuthResponseDTO login(LoginRequestDTO dto);
-    User getCurrentUser(String token);
 }

--- a/src/main/java/com/todoapp/auth/port/in/UserContextUseCase.java
+++ b/src/main/java/com/todoapp/auth/port/in/UserContextUseCase.java
@@ -1,0 +1,7 @@
+package com.todoapp.auth.port.in;
+
+import com.todoapp.user.domain.User;
+
+public interface UserContextUseCase {
+    User getCurrentUser(String token);
+}


### PR DESCRIPTION
This change refactors the authentication logic by:

- Renaming `AuthUseCase` to `LoginUseCase` to better reflect its purpose.
- Introducing `UserContextUseCase` to handle user retrieval based on the authentication token.
- This separation of concerns improves the design and maintainability of the authentication module.