### PR TITLE
Corrects createdAt handling and adds setter

### DIFF
--- a/src/main/java/com/todoapp/project/adapter/out/ProjectEntity.java
+++ b/src/main/java/com/todoapp/project/adapter/out/ProjectEntity.java
@@ -91,4 +91,8 @@ public class ProjectEntity {
         return createdAt;
     }
 
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
 }

--- a/src/main/java/com/todoapp/project/application/mapper/ProjectMapper.java
+++ b/src/main/java/com/todoapp/project/application/mapper/ProjectMapper.java
@@ -12,12 +12,10 @@ import java.util.List;
 public interface ProjectMapper {
 
     @Mapping(source = "userId", target = "userId")
-    @Mapping(source = "createdAt", target = "createdAt")
     ProjectResponseDTO toResponseDTO(Project project);
 
     @Mapping(target = "owner", ignore = true)
     @Mapping(target = "todoLists", ignore = true)
-    @Mapping(target = "createdAt", ignore = true)
     ProjectEntity domainToEntity(Project project);
 
     List<Project> entitiesToDomains(List<ProjectEntity> entities);

--- a/src/main/java/com/todoapp/project/domain/Project.java
+++ b/src/main/java/com/todoapp/project/domain/Project.java
@@ -15,7 +15,7 @@ public class Project {
         this.name = name;
         this.description = description;
         this.userId = userId;
-        this.createdAt = createdAt != null ? createdAt : LocalDateTime.now();
+        this.createdAt = createdAt;
     }
 
     // Getters y setters


### PR DESCRIPTION
Addresses an issue where the `createdAt` timestamp was being overwritten with the current time if null.

- Removes the default `LocalDateTime.now()` assignment in the `Project` constructor, ensuring that the original `createdAt` value is preserved when available.
- Introduces a `setCreatedAt` method in `ProjectEntity` to allow for updating the creation timestamp.