### PR TITLE
Adds test case for project not found scenario

### DIFF
--- a/src/test/java/com/todoapp/ProjectServiceTest.java
+++ b/src/test/java/com/todoapp/ProjectServiceTest.java
@@ -113,5 +113,19 @@ public class ProjectServiceTest {
         verify(ownershipValidator).validateProjectOwnership(projectId);
         verify(repository).save(existing);
     }
+    @Test
+    void shouldDeleteProjectWhenUserIsOwner() {
+        UUID projectId = UUID.randomUUID();
+        Project project = new Project(projectId, "ToDelete", "Desc", UUID.randomUUID(), null);
+
+        when(repository.findById(projectId)).thenReturn(project);
+        doNothing().when(ownershipValidator).validateProjectOwnership(projectId);
+        doNothing().when(repository).delete(projectId);
+
+        service.delete(projectId);
+
+        verify(ownershipValidator).validateProjectOwnership(projectId);
+        verify(repository).delete(projectId);
+    }
 
 }

--- a/src/test/java/com/todoapp/ProjectServiceTest.java
+++ b/src/test/java/com/todoapp/ProjectServiceTest.java
@@ -7,6 +7,7 @@ import com.todoapp.project.application.ProjectService;
 import com.todoapp.project.application.mapper.ProjectMapper;
 import com.todoapp.project.domain.Project;
 import com.todoapp.project.dto.ProjectResponseDTO;
+import com.todoapp.project.dto.ProjectUpdateDTO;
 import com.todoapp.project.port.out.ProjectRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -71,7 +72,7 @@ public class ProjectServiceTest {
     }
 
     @Test
-    void shouldThrowIfUserIsNotOwner(){
+    void shouldThrowIfUserIsNotOwner() {
         UUID projectId = UUID.randomUUID();
         Project project = new Project
                 (projectId,
@@ -91,4 +92,26 @@ public class ProjectServiceTest {
         });
         verify(ownershipValidator).validateProjectOwnership(projectId);
     }
+
+
+    @Test
+    void shouldUpdateProjectWhenUserIsOwner() {
+        UUID projectId = UUID.randomUUID();
+        Project existing = new Project(projectId, "Old Name", "Old Desc", UUID.randomUUID(), null);
+        ProjectUpdateDTO updateDTO = new ProjectUpdateDTO("New Name", null);
+
+        Project updated = new Project(projectId, "New Name", "Old Desc", existing.getUserId(), null);
+        ProjectResponseDTO expected = new ProjectResponseDTO(projectId, "New Name", "Old Desc", null, null);
+
+        when(repository.findById(projectId)).thenReturn(existing);
+        when(repository.save(existing)).thenReturn(updated);
+        when(mapper.toResponseDTO(updated)).thenReturn(expected);
+
+        ProjectResponseDTO result = service.update(projectId, updateDTO);
+
+        assertEquals(expected, result);
+        verify(ownershipValidator).validateProjectOwnership(projectId);
+        verify(repository).save(existing);
+    }
+
 }

--- a/src/test/java/com/todoapp/ProjectServiceTest.java
+++ b/src/test/java/com/todoapp/ProjectServiceTest.java
@@ -2,6 +2,7 @@ package com.todoapp;
 
 import com.todoapp.common.OwnershipValidator;
 import com.todoapp.common.UserProvider;
+import com.todoapp.common.exception.OwnershipException;
 import com.todoapp.project.application.ProjectService;
 import com.todoapp.project.application.mapper.ProjectMapper;
 import com.todoapp.project.domain.Project;
@@ -12,6 +13,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import static org.mockito.Mockito.doThrow;
+
 
 import java.util.NoSuchElementException;
 import java.util.UUID;
@@ -65,5 +68,27 @@ public class ProjectServiceTest {
             service.getById(projectId);
         });
         verify(repository).findById(projectId);
+    }
+
+    @Test
+    void shouldThrowIfUserIsNotOwner(){
+        UUID projectId = UUID.randomUUID();
+        Project project = new Project
+                (projectId,
+                        "Test Project",
+                        "Description",
+                        UUID.randomUUID(),
+                        null
+                );
+        when(repository.findById(projectId)).thenReturn(project); //simula que el encont el proyecto
+
+
+        doThrow(new OwnershipException("No autorizado")) //si el user no es el dueño del proyect
+                .when(ownershipValidator).validateProjectOwnership(projectId);
+
+        assertThrows(OwnershipException.class, () -> {
+            service.getById(projectId);
+        });
+        verify(ownershipValidator).validateProjectOwnership(projectId);
     }
 }

--- a/src/test/java/com/todoapp/ProjectServiceTest.java
+++ b/src/test/java/com/todoapp/ProjectServiceTest.java
@@ -13,9 +13,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.NoSuchElementException;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -33,7 +35,6 @@ public class ProjectServiceTest {
 
     @Test
     public void shouldReturnProjectWhenUserOwnsIt() {
-
         UUID projectId = UUID.randomUUID();
         Project project = new Project(projectId, "Test Project", "Description", UUID.randomUUID(), null);
         ProjectResponseDTO expectedResponse = new ProjectResponseDTO(
@@ -52,5 +53,17 @@ public class ProjectServiceTest {
 
         assertEquals(expectedResponse, result);
         verify(ownershipValidator).validateProjectOwnership(projectId);
+    }
+
+    @Test
+    void shouldThrowWhenProjectNotFound() {
+        UUID projectId = UUID.randomUUID();
+
+        when(repository.findById(projectId)).thenThrow(new NoSuchElementException("Proyecto no existe"));
+
+        assertThrows(NoSuchElementException.class, () -> {
+            service.getById(projectId);
+        });
+        verify(repository).findById(projectId);
     }
 }


### PR DESCRIPTION
Adds a unit test to verify that a `NoSuchElementException` is thrown when attempting to retrieve a project by ID that does not exist.

This ensures that the application handles the case where a project is not found gracefully and provides a clear indication to the user.