### PR TITLE
Removes exception on empty task/todolist results

### DIFF
--- a/src/main/java/com/todoapp/task/adapter/out/TaskRepositoryImpl.java
+++ b/src/main/java/com/todoapp/task/adapter/out/TaskRepositoryImpl.java
@@ -44,9 +44,6 @@ public class TaskRepositoryImpl implements TaskRepository {
     @Override
     public List<Task> findByTodoListId(UUID todoListId) {
         List<TaskEntity> entities = jpa.findByTodoListId(todoListId);
-        if (entities.isEmpty()) {
-            throw new NoSuchElementException("No se encontraron tareas para la lista de tareas con id: " + todoListId);
-        }
         return mapper.entitiesToDomains(entities);
     }
 

--- a/src/main/java/com/todoapp/todolist/adapter/out/TodoListRepositoryImpl.java
+++ b/src/main/java/com/todoapp/todolist/adapter/out/TodoListRepositoryImpl.java
@@ -57,9 +57,6 @@ public class TodoListRepositoryImpl implements TodoListRepository {
     @Override
     public List<TodoList> findByUserId(UUID userId) {
         List<TodoListEntity> entities = jpa.findByProject_Owner_Id(userId);
-        if (entities.isEmpty()) {
-            throw new NoSuchElementException("No se encontraron listas de tareas para el usuario con id: " + userId);
-        }
         return mapper.entitiesToDomains(entities);
     }
 


### PR DESCRIPTION
Removes the `NoSuchElementException` thrown when no tasks are found for a given todo list or no todo lists are found for a given user. This change prevents unnecessary exceptions being thrown when a user or todolist has no associated tasks/todolists.