### PR TITLE
Updates TodoList save to handle existing entities

### DIFF
--- a/src/main/java/com/todoapp/todolist/adapter/out/TodoListRepositoryImpl.java
+++ b/src/main/java/com/todoapp/todolist/adapter/out/TodoListRepositoryImpl.java
@@ -27,8 +27,14 @@ public class TodoListRepositoryImpl implements TodoListRepository {
 
     @Override
     public TodoList save(TodoList todoList) {
-        TodoListEntity entity = mapper.domainToEntity(todoList);
-        entity.setProject(entityManager.getReference(ProjectEntity.class, todoList.getProjectId()));
+        TodoListEntity entity;
+        if(todoList.getId() != null && jpa.existsById(todoList.getId())) {
+            entity = jpa.findById(todoList.getId()).orElseThrow();
+            entity.setName(todoList.getName());
+        }else{
+            entity = mapper.domainToEntity(todoList);
+            entity.setProject(entityManager.getReference(ProjectEntity.class, todoList.getProjectId()));
+        }
         TodoListEntity savedEntity = jpa.save(entity);
         return mapper.entityToDomain(savedEntity);
     }


### PR DESCRIPTION
Updates the `save` method in the `TodoListRepositoryImpl` to handle both creating new `TodoList` entities and updating existing ones.

- If a `TodoList` entity with the given ID already exists, it updates the entity's name instead of creating a new one.
- This ensures data consistency and prevents duplicate entries when updating existing todo lists.