### PR TITLE
Removes exception for empty user projects

### DIFF
--- a/src/main/java/com/todoapp/project/adapter/out/ProjectRepositoryImpl.java
+++ b/src/main/java/com/todoapp/project/adapter/out/ProjectRepositoryImpl.java
@@ -54,9 +54,6 @@ public class ProjectRepositoryImpl implements ProjectRepository {
     @Override
     public List<Project> findByUserId(UUID userId) {
         List<ProjectEntity> entities = jpaRepository.findByOwnerId(userId);
-        if (entities.isEmpty()) {
-            throw new NoSuchElementException("No se encontraron proyectos para el usuario con id: " + userId);
-        }
         return mapper.entitiesToDomains(entities);
     }
 


### PR DESCRIPTION
Removes the exception thrown when no projects are found for a given user.

This change prevents the application from throwing an error when a user has no associated projects, allowing the application to handle empty project lists gracefully.