### PR TITLE
Removes exception for empty user results

### DIFF
--- a/src/main/java/com/todoapp/project/adapter/out/ProjectRepositoryImpl.java
+++ b/src/main/java/com/todoapp/project/adapter/out/ProjectRepositoryImpl.java
@@ -54,9 +54,6 @@ public class ProjectRepositoryImpl implements ProjectRepository {
     @Override
     public List<Project> findByUserId(UUID userId) {
         List<ProjectEntity> entities = jpaRepository.findByOwnerId(userId);
-        if (entities.isEmpty()) {
-            throw new NoSuchElementException("No se encontraron proyectos para el usuario con id: " + userId);
-        }
         return mapper.entitiesToDomains(entities);
     }
 

--- a/src/main/java/com/todoapp/todolist/adapter/out/TodoListRepositoryImpl.java
+++ b/src/main/java/com/todoapp/todolist/adapter/out/TodoListRepositoryImpl.java
@@ -27,8 +27,14 @@ public class TodoListRepositoryImpl implements TodoListRepository {
 
     @Override
     public TodoList save(TodoList todoList) {
-        TodoListEntity entity = mapper.domainToEntity(todoList);
-        entity.setProject(entityManager.getReference(ProjectEntity.class, todoList.getProjectId()));
+        TodoListEntity entity;
+        if(todoList.getId() != null && jpa.existsById(todoList.getId())) {
+            entity = jpa.findById(todoList.getId()).orElseThrow();
+            entity.setName(todoList.getName());
+        }else{
+            entity = mapper.domainToEntity(todoList);
+            entity.setProject(entityManager.getReference(ProjectEntity.class, todoList.getProjectId()));
+        }
         TodoListEntity savedEntity = jpa.save(entity);
         return mapper.entityToDomain(savedEntity);
     }


### PR DESCRIPTION
Removes the exception thrown when no results are found for a user ID.

This prevents unexpected errors when a user has no associated data, allowing the application to handle empty results gracefully.