### PR TITLE
Enables task reordering within Todo lists

### DIFF
--- a/src/main/java/com/todoapp/task/adapter/in/TaskController.java
+++ b/src/main/java/com/todoapp/task/adapter/in/TaskController.java
@@ -82,4 +82,25 @@ public class TaskController {
         useCase.delete(taskId, todoListId, projectId);
         return ResponseEntity.noContent().build();
     }
+
+    @PatchMapping("/reorder")
+    public ResponseEntity<?> reorderTasks(
+            @PathVariable UUID projectId,
+            @PathVariable UUID todoListId,
+            @RequestBody(required = false) TaskReorderDTO reorderDTO) {
+        if (reorderDTO == null || reorderDTO.getTaskIds() == null) {
+            return ResponseEntity.badRequest().body("El cuerpo de la petición debe incluir el campo 'taskIds' como un array.");
+        }
+        try {
+            List<TaskResponseDTO> updatedTasks = useCase.reorderTasks(projectId, todoListId, reorderDTO.getTaskIds());
+            return ResponseEntity.ok(updatedTasks);
+        } catch (org.springframework.web.server.ResponseStatusException e) {
+            return ResponseEntity.status(e.getStatusCode()).body(e.getReason());
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(500).body("Error interno del servidor: " + (e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName()));
+        }
+    }
 }

--- a/src/main/java/com/todoapp/task/adapter/out/TaskEntity.java
+++ b/src/main/java/com/todoapp/task/adapter/out/TaskEntity.java
@@ -23,6 +23,9 @@ public class TaskEntity {
 
     private LocalDate dueDate;
 
+    @Column(nullable = false)
+    private int position;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "todo_list_id", nullable = false)
     private TodoListEntity todoList;
@@ -77,6 +80,14 @@ public class TaskEntity {
 
     public void setDueDate(LocalDate dueDate) {
         this.dueDate = dueDate;
+    }
+
+    public int getPosition() {
+        return position;
+    }
+
+    public void setPosition(int position) {
+        this.position = position;
     }
 
     public TodoListEntity getTodoList() {

--- a/src/main/java/com/todoapp/task/adapter/out/TaskJpaRepository.java
+++ b/src/main/java/com/todoapp/task/adapter/out/TaskJpaRepository.java
@@ -8,4 +8,5 @@ import java.util.UUID;
 
 public interface TaskJpaRepository extends JpaRepository<TaskEntity, UUID> {
     List<TaskEntity> findByTodoListId(UUID todoListId);
+    List<TaskEntity> findByTodoListIdOrderByPositionAsc(UUID todoListId);
 }

--- a/src/main/java/com/todoapp/task/adapter/out/TaskRepositoryImpl.java
+++ b/src/main/java/com/todoapp/task/adapter/out/TaskRepositoryImpl.java
@@ -43,8 +43,10 @@ public class TaskRepositoryImpl implements TaskRepository {
 
     @Override
     public List<Task> findByTodoListId(UUID todoListId) {
-        List<TaskEntity> entities = jpa.findByTodoListId(todoListId);
-        return mapper.entitiesToDomains(entities);
+        return jpa.findByTodoListIdOrderByPositionAsc(todoListId)
+                .stream()
+                .map(mapper::entityToDomain)
+                .toList();
     }
 
     @Override

--- a/src/main/java/com/todoapp/task/application/mapper/TaskMapper.java
+++ b/src/main/java/com/todoapp/task/application/mapper/TaskMapper.java
@@ -12,8 +12,10 @@ import java.util.List;
 public interface TaskMapper {
     @Mapping(target = "todoListId", source = "todoList.id")
     @Mapping(target = "projectId", source = "todoList.project.id")
+    @Mapping(target = "position", source = "position")
     Task entityToDomain(TaskEntity taskEntity);
 
+    @Mapping(target = "position", source = "position")
     TaskEntity domainToEntity(Task task);
     TaskResponseDTO toResponseDTO(Task task);
     List<Task> entitiesToDomains(List<TaskEntity> taskEntities);

--- a/src/main/java/com/todoapp/task/domain/Task.java
+++ b/src/main/java/com/todoapp/task/domain/Task.java
@@ -11,6 +11,7 @@ public class Task {
     private LocalDate dueDate;
     private UUID todoListId;
     private UUID projectId;
+    private int position;
 
     public Task(UUID id, String title, String description, boolean completed,
                 LocalDate dueDate, UUID todoListId) {
@@ -76,5 +77,13 @@ public class Task {
 
     public void setProjectId(UUID projectId) {
         this.projectId = projectId;
+    }
+
+    public int getPosition() {
+        return position;
+    }
+
+    public void setPosition(int position) {
+        this.position = position;
     }
 }

--- a/src/main/java/com/todoapp/task/dto/TaskReorderDTO.java
+++ b/src/main/java/com/todoapp/task/dto/TaskReorderDTO.java
@@ -1,0 +1,15 @@
+package com.todoapp.task.dto;
+
+import java.util.List;
+
+public class TaskReorderDTO {
+    private List<String> taskIds;
+
+    public List<String> getTaskIds() {
+        return taskIds;
+    }
+
+    public void setTaskIds(List<String> taskIds) {
+        this.taskIds = taskIds;
+    }
+}

--- a/src/main/java/com/todoapp/task/dto/TaskResponseDTO.java
+++ b/src/main/java/com/todoapp/task/dto/TaskResponseDTO.java
@@ -9,5 +9,6 @@ public record TaskResponseDTO(
         boolean completed,
         LocalDate dueDate,
         UUID todoListId,
-        UUID projectId
+        UUID projectId,
+        int position
 ) {}

--- a/src/main/java/com/todoapp/task/port/in/TaskUseCase.java
+++ b/src/main/java/com/todoapp/task/port/in/TaskUseCase.java
@@ -11,4 +11,5 @@ public interface TaskUseCase {
     TaskResponseDTO update(UUID id, TaskUpdateDTO dto, UUID todoListId, UUID projectId);
     TaskResponseDTO updateStatus(UUID id, TaskStatusUpdateDTO dto, UUID todoListId, UUID projectId);
     void delete(UUID id, UUID todoListId, UUID projectId);
+    List<TaskResponseDTO> reorderTasks(UUID projectId, UUID todoListId, List<String> taskIds);
 }

--- a/src/test/java/com/todoapp/task/adapter/in/TaskControllerTest.java
+++ b/src/test/java/com/todoapp/task/adapter/in/TaskControllerTest.java
@@ -44,7 +44,7 @@ class TaskControllerTest {
     @Test
     void shouldCreateTaskSuccessfully() throws Exception {
         TaskResponseDTO response = new TaskResponseDTO(
-                taskId, "Test Task", "Test Description", false, dueDate, todoListId, projectId
+                taskId, "Test Task", "Test Description", false, dueDate, todoListId, projectId, 0
         );
 
         when(taskUseCase.create(any(TaskCreateDTO.class)))
@@ -60,7 +60,8 @@ class TaskControllerTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id").exists())
                 .andExpect(jsonPath("$.title").value("Test Task"))
-                .andExpect(jsonPath("$.description").value("Test Description"));
+                .andExpect(jsonPath("$.description").value("Test Description"))
+                .andExpect(jsonPath("$.position").value(0));
     }
 
     @Test
@@ -78,7 +79,7 @@ class TaskControllerTest {
     @Test
     void shouldGetTaskByIdSuccessfully() throws Exception {
         TaskResponseDTO response = new TaskResponseDTO(
-                taskId, "Test Task", "Test Description", false, dueDate, todoListId, projectId
+                taskId, "Test Task", "Test Description", false, dueDate, todoListId, projectId, 0
         );
 
         when(taskUseCase.getById(taskId, todoListId, projectId))
@@ -88,16 +89,17 @@ class TaskControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(taskId.toString()))
                 .andExpect(jsonPath("$.title").value("Test Task"))
-                .andExpect(jsonPath("$.description").value("Test Description"));
+                .andExpect(jsonPath("$.description").value("Test Description"))
+                .andExpect(jsonPath("$.position").value(0));
     }
 
     @Test
     void shouldGetTasksByTodoListSuccessfully() throws Exception {
         TaskResponseDTO task1 = new TaskResponseDTO(
-                taskId, "Task 1", "Description 1", false, dueDate, todoListId, projectId
+                taskId, "Task 1", "Description 1", false, dueDate, todoListId, projectId, 0
         );
         TaskResponseDTO task2 = new TaskResponseDTO(
-                UUID.randomUUID(), "Task 2", "Description 2", true, dueDate, todoListId, projectId
+                UUID.randomUUID(), "Task 2", "Description 2", true, dueDate, todoListId, projectId, 1
         );
 
         when(taskUseCase.getByTodoListId(todoListId, projectId))
@@ -113,7 +115,7 @@ class TaskControllerTest {
     @Test
     void shouldUpdateTaskSuccessfully() throws Exception {
         TaskResponseDTO response = new TaskResponseDTO(
-                taskId, "Updated Task", "Updated Description", false, dueDate, todoListId, projectId
+                taskId, "Updated Task", "Updated Description", false, dueDate, todoListId, projectId, 0
         );
 
         when(taskUseCase.update(eq(taskId), any(TaskUpdateDTO.class), eq(todoListId), eq(projectId)))
@@ -134,7 +136,7 @@ class TaskControllerTest {
     @Test
     void shouldUpdateTaskStatusSuccessfully() throws Exception {
         TaskResponseDTO response = new TaskResponseDTO(
-                taskId, "Test Task", "Test Description", true, dueDate, todoListId, projectId
+                taskId, "Test Task", "Test Description", true, dueDate, todoListId, projectId, 0
         );
 
         when(taskUseCase.updateStatus(eq(taskId), any(TaskStatusUpdateDTO.class), eq(todoListId), eq(projectId)))
@@ -148,7 +150,8 @@ class TaskControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(json))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.completed").value("true"));
+                .andExpect(jsonPath("$.completed").value("true"))
+                .andExpect(jsonPath("$.position").value(0));
     }
 
     @Test
@@ -173,4 +176,4 @@ class TaskControllerTest {
             return http.build();
         }
     }
-} 
+}

--- a/src/test/java/com/todoapp/task/application/TaskServiceTest.java
+++ b/src/test/java/com/todoapp/task/application/TaskServiceTest.java
@@ -58,7 +58,7 @@ class TaskServiceTest {
         // Given
         TaskCreateDTO createDTO = new TaskCreateDTO("Test Task", "Test Description", dueDate, todoListId, projectId);
         Task task = new Task(taskId, "Test Task", "Test Description", false, dueDate, todoListId);
-        TaskResponseDTO expectedResponse = new TaskResponseDTO(taskId, "Test Task", "Test Description", false, dueDate, todoListId, projectId);
+        TaskResponseDTO expectedResponse = new TaskResponseDTO(taskId, "Test Task", "Test Description", false, dueDate, todoListId, projectId, 0);
 
         when(taskRepository.save(any(Task.class))).thenReturn(task);
         when(taskMapper.toResponseDTO(task)).thenReturn(expectedResponse);
@@ -77,7 +77,7 @@ class TaskServiceTest {
     void shouldGetTaskByIdSuccessfully() {
         // Given
         Task task = new Task(taskId, "Test Task", "Test Description", false, dueDate, todoListId);
-        TaskResponseDTO expectedResponse = new TaskResponseDTO(taskId, "Test Task", "Test Description", false, dueDate, todoListId, projectId);
+        TaskResponseDTO expectedResponse = new TaskResponseDTO(taskId, "Test Task", "Test Description", false, dueDate, todoListId, projectId, 0);
 
         when(taskRepository.existsById(taskId)).thenReturn(true);
         when(taskRepository.findById(taskId)).thenReturn(task);
@@ -89,6 +89,7 @@ class TaskServiceTest {
 
         // Then
         assertThat(result).isEqualTo(expectedResponse);
+        verify(taskRepository).existsById(taskId);
         verify(taskRepository).findById(taskId);
         verify(ownershipValidator).validateTodoListOwnership(todoListId, projectId);
     }
@@ -124,8 +125,8 @@ class TaskServiceTest {
         // Given
         Task task1 = new Task(taskId, "Task 1", "Description 1", false, dueDate, todoListId);
         Task task2 = new Task(UUID.randomUUID(), "Task 2", "Description 2", true, dueDate, todoListId);
-        TaskResponseDTO response1 = new TaskResponseDTO(taskId, "Task 1", "Description 1", false, dueDate, todoListId, projectId);
-        TaskResponseDTO response2 = new TaskResponseDTO(UUID.randomUUID(), "Task 2", "Description 2", true, dueDate, todoListId, projectId);
+        TaskResponseDTO response1 = new TaskResponseDTO(taskId, "Task 1", "Description 1", false, dueDate, todoListId, projectId, 0);
+        TaskResponseDTO response2 = new TaskResponseDTO(UUID.randomUUID(), "Task 2", "Description 2", true, dueDate, todoListId, projectId, 1);
 
         when(taskRepository.findByTodoListId(todoListId)).thenReturn(Arrays.asList(task1, task2));
         when(taskMapper.toResponseDTO(task1)).thenReturn(response1);
@@ -148,7 +149,7 @@ class TaskServiceTest {
         TaskUpdateDTO updateDTO = new TaskUpdateDTO("Updated Task", "Updated Description", dueDate);
         Task task = new Task(taskId, "Original Task", "Original Description", false, dueDate, todoListId);
         Task updatedTask = new Task(taskId, "Updated Task", "Updated Description", false, dueDate, todoListId);
-        TaskResponseDTO expectedResponse = new TaskResponseDTO(taskId, "Updated Task", "Updated Description", false, dueDate, todoListId, projectId);
+        TaskResponseDTO expectedResponse = new TaskResponseDTO(taskId, "Updated Task", "Updated Description", false, dueDate, todoListId, projectId, 1);
 
         when(taskRepository.existsById(taskId)).thenReturn(true);
         when(taskRepository.findById(taskId)).thenReturn(task);
@@ -174,7 +175,7 @@ class TaskServiceTest {
         TaskStatusUpdateDTO statusDTO = new TaskStatusUpdateDTO(true);
         Task task = new Task(taskId, "Test Task", "Test Description", false, dueDate, todoListId);
         Task updatedTask = new Task(taskId, "Test Task", "Test Description", true, dueDate, todoListId);
-        TaskResponseDTO expectedResponse = new TaskResponseDTO(taskId, "Test Task", "Test Description", true, dueDate, todoListId, projectId);
+        TaskResponseDTO expectedResponse = new TaskResponseDTO(taskId, "Test Task", "Test Description", true, dueDate, todoListId, projectId,1);
 
         when(taskRepository.existsById(taskId)).thenReturn(true);
         when(taskRepository.findById(taskId)).thenReturn(task);
@@ -221,4 +222,4 @@ class TaskServiceTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Task with ID " + taskId + " does not exist");
     }
-} 
+}

--- a/src/test/java/com/todoapp/task/dto/TaskResponseDTOTest.java
+++ b/src/test/java/com/todoapp/task/dto/TaskResponseDTOTest.java
@@ -13,9 +13,9 @@ class TaskResponseDTOTest {
         UUID todoListId = UUID.randomUUID();
         UUID projectId = UUID.randomUUID();
         LocalDate dueDate = LocalDate.now().plusDays(7);
-        
-        TaskResponseDTO dto = new TaskResponseDTO(taskId, "Test Task", "Test Description", false, dueDate, todoListId, projectId);
-        
+        int position = 3;
+        TaskResponseDTO dto = new TaskResponseDTO(taskId, "Test Task", "Test Description", false, dueDate, todoListId, projectId, position);
+
         assertThat(dto.id()).isEqualTo(taskId);
         assertThat(dto.title()).isEqualTo("Test Task");
         assertThat(dto.description()).isEqualTo("Test Description");
@@ -23,6 +23,7 @@ class TaskResponseDTOTest {
         assertThat(dto.dueDate()).isEqualTo(dueDate);
         assertThat(dto.todoListId()).isEqualTo(todoListId);
         assertThat(dto.projectId()).isEqualTo(projectId);
+        assertThat(dto.position()).isEqualTo(position);
     }
 
     @Test
@@ -31,10 +32,11 @@ class TaskResponseDTOTest {
         UUID todoListId = UUID.randomUUID();
         UUID projectId = UUID.randomUUID();
         LocalDate dueDate = LocalDate.now().plusDays(7);
-        
-        TaskResponseDTO dto1 = new TaskResponseDTO(taskId, "Test Task", "Test Description", false, dueDate, todoListId, projectId);
-        TaskResponseDTO dto2 = new TaskResponseDTO(taskId, "Test Task", "Test Description", false, dueDate, todoListId, projectId);
-        
+        int position = 3;
+
+        TaskResponseDTO dto1 = new TaskResponseDTO(taskId, "Test Task", "Test Description", false, dueDate, todoListId, projectId, position);
+        TaskResponseDTO dto2 = new TaskResponseDTO(taskId, "Test Task", "Test Description", false, dueDate, todoListId, projectId, position);
+
         assertThat(dto1).isEqualTo(dto2);
     }
 
@@ -43,9 +45,10 @@ class TaskResponseDTOTest {
         UUID taskId = UUID.randomUUID();
         UUID todoListId = UUID.randomUUID();
         UUID projectId = UUID.randomUUID();
-        
-        TaskResponseDTO dto = new TaskResponseDTO(taskId, "Test Task", null, false, null, todoListId, projectId);
-        
+        int position = 3;
+
+        TaskResponseDTO dto = new TaskResponseDTO(taskId, "Test Task", null, false, null, todoListId, projectId, position);
+
         assertThat(dto.id()).isEqualTo(taskId);
         assertThat(dto.title()).isEqualTo("Test Task");
         assertThat(dto.description()).isNull();
@@ -53,6 +56,7 @@ class TaskResponseDTOTest {
         assertThat(dto.dueDate()).isNull();
         assertThat(dto.todoListId()).isEqualTo(todoListId);
         assertThat(dto.projectId()).isEqualTo(projectId);
+        assertThat(dto.position()).isEqualTo(position);
     }
 
     @Test
@@ -61,9 +65,10 @@ class TaskResponseDTOTest {
         UUID todoListId = UUID.randomUUID();
         UUID projectId = UUID.randomUUID();
         LocalDate dueDate = LocalDate.now().plusDays(7);
-        
-        TaskResponseDTO dto = new TaskResponseDTO(taskId, "Test Task", "Test Description", true, dueDate, todoListId, projectId);
-        
+        int position = 3;
+
+        TaskResponseDTO dto = new TaskResponseDTO(taskId, "Test Task", "Test Description", true, dueDate, todoListId, projectId, position);
+
         assertThat(dto.completed()).isEqualTo(false);
     }
 
@@ -73,9 +78,10 @@ class TaskResponseDTOTest {
         UUID todoListId = UUID.randomUUID();
         UUID projectId = UUID.randomUUID();
         LocalDate dueDate = LocalDate.now().plusDays(7);
-        
-        TaskResponseDTO dto = new TaskResponseDTO(taskId, "Test Task", "Test Description", false, dueDate, todoListId, projectId);
-        
+        int position = 3;
+
+        TaskResponseDTO dto = new TaskResponseDTO(taskId, "Test Task", "Test Description", false, dueDate, todoListId, projectId, position);
+
         assertThat(dto.completed()).isEqualTo(false);
     }
 
@@ -85,9 +91,10 @@ class TaskResponseDTOTest {
         UUID todoListId = UUID.randomUUID();
         UUID projectId = UUID.randomUUID();
         LocalDate dueDate = LocalDate.now().plusDays(7);
-        
-        TaskResponseDTO dto = new TaskResponseDTO(taskId, "Test Task", "", false, dueDate, todoListId, projectId);
-        
+        int position = 3;
+
+        TaskResponseDTO dto = new TaskResponseDTO(taskId, "Test Task", "", false, dueDate, todoListId, projectId, position);
+
         assertThat(dto.description()).isEqualTo("");
     }
 
@@ -97,9 +104,10 @@ class TaskResponseDTOTest {
         UUID todoListId = UUID.randomUUID();
         UUID projectId = UUID.randomUUID();
         LocalDate pastDate = LocalDate.now().minusDays(1);
-        
-        TaskResponseDTO dto = new TaskResponseDTO(taskId, "Test Task", "Test Description", false, pastDate, todoListId, projectId);
-        
+        int position = 3;
+
+        TaskResponseDTO dto = new TaskResponseDTO(taskId, "Test Task", "Test Description", false, pastDate, todoListId, projectId, position);
+
         assertThat(dto.dueDate()).isEqualTo(pastDate);
     }
 
@@ -109,9 +117,10 @@ class TaskResponseDTOTest {
         UUID todoListId = UUID.randomUUID();
         UUID projectId = UUID.randomUUID();
         LocalDate futureDate = LocalDate.now().plusDays(30);
-        
-        TaskResponseDTO dto = new TaskResponseDTO(taskId, "Test Task", "Test Description", false, futureDate, todoListId, projectId);
-        
+        int position = 3;
+
+        TaskResponseDTO dto = new TaskResponseDTO(taskId, "Test Task", "Test Description", false, futureDate, todoListId, projectId, position);
+
         assertThat(dto.dueDate()).isEqualTo(futureDate);
     }
 
@@ -121,9 +130,10 @@ class TaskResponseDTOTest {
         UUID todoListId = UUID.randomUUID();
         UUID projectId = UUID.randomUUID();
         LocalDate today = LocalDate.now();
-        
-        TaskResponseDTO dto = new TaskResponseDTO(taskId, "Test Task", "Test Description", false, today, todoListId, projectId);
-        
+        int position = 3;
+
+        TaskResponseDTO dto = new TaskResponseDTO(taskId, "Test Task", "Test Description", false, today, todoListId, projectId, position);
+
         assertThat(dto.dueDate()).isEqualTo(today);
     }
-} 
+}


### PR DESCRIPTION
Implements the ability to reorder tasks within a Todo list by introducing a position field and a dedicated API endpoint.

Key changes:
- Adds a `position` field to both the `Task` domain object and the `TaskEntity` for storing task order.
- Introduces a `TaskReorderDTO` to handle the list of task IDs for reordering.
- Creates a `reorderTasks` endpoint in `TaskController` to manage the reordering request.
- Modifies the task repository to fetch tasks ordered by their position.
- Updates the `TaskMapper` to map the position attribute between entities and domains.

This feature enhances the user experience by allowing them to easily customize the order of tasks in their lists.